### PR TITLE
fix: resolve the route with query params

### DIFF
--- a/src/runtime/modal-router.ts
+++ b/src/runtime/modal-router.ts
@@ -98,7 +98,7 @@ export default defineNuxtPlugin(async (nuxt) => {
     const state = { id: `plus-${Date.now()}`, backgroundView } satisfies ModalPushRecord
 
     const _to = {
-      ...(typeof to === "string" ? router.resolve(to) : to),
+      ...(typeof to === 'string' ? router.resolve(to) : to),
       state,
     }
 

--- a/src/runtime/modal-router.ts
+++ b/src/runtime/modal-router.ts
@@ -98,7 +98,7 @@ export default defineNuxtPlugin(async (nuxt) => {
     const state = { id: `plus-${Date.now()}`, backgroundView } satisfies ModalPushRecord
 
     const _to = {
-      ...(typeof to === 'string' ? { path: to } : to),
+      ...(typeof to === "string" ? router.resolve(to) : to),
       state,
     }
 


### PR DESCRIPTION
Resolves #26 

Hey! Looks like using `router.resolve(to)` instead of `{ path: to }` fixes the issue.